### PR TITLE
Update config to recognize 1.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If you'd like to help us translate this project into other languages, it would b
 > Wiki: https://github.com/SPGoding/datapack-language-server/wiki/Semantic-Coloring
 
 All command arguments can be colored semantically. We also encourage you to install
-[Arcensoth](https://github.com/Arcensotj)'s [language-mcfunction extension](https://github.com/Arcensoth/language-mcfunction)
+the [syntax-mcfunction extension](https://github.com/MinecraftCommands/syntax-mcfunction)
 to get instant coloring feedback.
 
 ![semantic-coloring](https://raw.githubusercontent.com/SPGoding/vscode-datapack-helper-plus/master/img/semantic-coloring.png)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.4.16",
             "license": "MIT",
             "dependencies": {
-                "@spgoding/datapack-language-server": "3.4.16",
+                "@spgoding/datapack-language-server": "3.4.17",
                 "vscode-languageclient": "^7.0.0"
             },
             "devDependencies": {
@@ -210,10 +210,18 @@
                 "@mcschema/core": "^0.12.39"
             }
         },
+        "node_modules/@mcschema/java-1.20.2": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@mcschema/java-1.20.2/-/java-1.20.2-0.0.4.tgz",
+            "integrity": "sha512-2Kkxe5i+ivSJYAwugwqaPwl4fwSxARh6RmB27o2QrJ/f+bp1Krzg4NS57lmsP8+4FN9x9X0DyPuj82hQerD83A==",
+            "dependencies": {
+                "@mcschema/core": "^0.12.40"
+            }
+        },
         "node_modules/@mcschema/locales": {
-            "version": "0.1.87",
-            "resolved": "https://registry.npmjs.org/@mcschema/locales/-/locales-0.1.87.tgz",
-            "integrity": "sha512-KocgK7GTsXzi2QKIt46W1vhw2wGLR7qEvbRn+aPr2FPxKz/+XgEFHWp11Wl38i5P4lvmNnOfObB1aON6fmysew=="
+            "version": "0.1.89",
+            "resolved": "https://registry.npmjs.org/@mcschema/locales/-/locales-0.1.89.tgz",
+            "integrity": "sha512-veFdi5ajeX0HtQVx/S1Gj1w2WBuw+WYfkn0LK0W6ew4EXS3d5Q8wwMjvHq26RX/B/g1Bzq/sH3fT3xO0JR1QbA=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.3",
@@ -812,9 +820,9 @@
             }
         },
         "node_modules/@spgoding/datapack-language-server": {
-            "version": "3.4.16",
-            "resolved": "https://registry.npmjs.org/@spgoding/datapack-language-server/-/datapack-language-server-3.4.16.tgz",
-            "integrity": "sha512-b4rlpk/LGwbqZ0xr7QKSSY7yCK/4+gC92j/E4t4644y3T+zE2diFDj/23j6B1hailTZPUHDQCGCZQVSvUuuYSQ==",
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@spgoding/datapack-language-server/-/datapack-language-server-3.4.17.tgz",
+            "integrity": "sha512-s/2z6FBr8WNOcRLS9Qvibcv+zb6x2nJddZ2l22S6MBcHYJ1fej4Tf/lVbDegHL721muVzipnpUGaiDqtLKkGrg==",
             "dependencies": {
                 "@mcschema/core": "^0.12.40",
                 "@mcschema/java-1.16": "^0.6.14",
@@ -825,7 +833,8 @@
                 "@mcschema/java-1.19.3": "^0.0.8",
                 "@mcschema/java-1.19.4": "^0.1.11",
                 "@mcschema/java-1.20": "^0.0.12",
-                "@mcschema/locales": "^0.1.87",
+                "@mcschema/java-1.20.2": "^0.0.4",
+                "@mcschema/locales": "^0.1.88",
                 "appdata-path": "^1.0.0",
                 "clone": "^2.1.2",
                 "fast-deep-equal": "^3.1.3",
@@ -17135,10 +17144,18 @@
                 "@mcschema/core": "^0.12.39"
             }
         },
+        "@mcschema/java-1.20.2": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@mcschema/java-1.20.2/-/java-1.20.2-0.0.4.tgz",
+            "integrity": "sha512-2Kkxe5i+ivSJYAwugwqaPwl4fwSxARh6RmB27o2QrJ/f+bp1Krzg4NS57lmsP8+4FN9x9X0DyPuj82hQerD83A==",
+            "requires": {
+                "@mcschema/core": "^0.12.40"
+            }
+        },
         "@mcschema/locales": {
-            "version": "0.1.87",
-            "resolved": "https://registry.npmjs.org/@mcschema/locales/-/locales-0.1.87.tgz",
-            "integrity": "sha512-KocgK7GTsXzi2QKIt46W1vhw2wGLR7qEvbRn+aPr2FPxKz/+XgEFHWp11Wl38i5P4lvmNnOfObB1aON6fmysew=="
+            "version": "0.1.89",
+            "resolved": "https://registry.npmjs.org/@mcschema/locales/-/locales-0.1.89.tgz",
+            "integrity": "sha512-veFdi5ajeX0HtQVx/S1Gj1w2WBuw+WYfkn0LK0W6ew4EXS3d5Q8wwMjvHq26RX/B/g1Bzq/sH3fT3xO0JR1QbA=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.3",
@@ -17603,9 +17620,9 @@
             "dev": true
         },
         "@spgoding/datapack-language-server": {
-            "version": "3.4.16",
-            "resolved": "https://registry.npmjs.org/@spgoding/datapack-language-server/-/datapack-language-server-3.4.16.tgz",
-            "integrity": "sha512-b4rlpk/LGwbqZ0xr7QKSSY7yCK/4+gC92j/E4t4644y3T+zE2diFDj/23j6B1hailTZPUHDQCGCZQVSvUuuYSQ==",
+            "version": "3.4.17",
+            "resolved": "https://registry.npmjs.org/@spgoding/datapack-language-server/-/datapack-language-server-3.4.17.tgz",
+            "integrity": "sha512-s/2z6FBr8WNOcRLS9Qvibcv+zb6x2nJddZ2l22S6MBcHYJ1fej4Tf/lVbDegHL721muVzipnpUGaiDqtLKkGrg==",
             "requires": {
                 "@mcschema/core": "^0.12.40",
                 "@mcschema/java-1.16": "^0.6.14",
@@ -17616,7 +17633,8 @@
                 "@mcschema/java-1.19.3": "^0.0.8",
                 "@mcschema/java-1.19.4": "^0.1.11",
                 "@mcschema/java-1.20": "^0.0.12",
-                "@mcschema/locales": "^0.1.87",
+                "@mcschema/java-1.20.2": "^0.0.4",
+                "@mcschema/locales": "^0.1.88",
                 "appdata-path": "^1.0.0",
                 "clone": "^2.1.2",
                 "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -246,10 +246,11 @@
                         "1.19",
                         "1.19.3",
                         "1.19.4",
-                        "1.20"
+                        "1.20",
+                        "1.20.2"
                     ],
                     "markdownDescription": "%datapack.config.env.cmdVersion%",
-                    "default": "1.20"
+                    "default": "1.20.2"
                 },
                 "datapack.env.dataVersion": {
                     "anyOf": [

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "publisher": "SPGoding",
     "license": "MIT",
     "scripts": {
-        "build": "NODE_OPTIONS=--openssl-legacy-provider webpack",
-        "build:dev": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode=\"development\"",
-        "build:profile": "NODE_OPTIONS=--openssl-legacy-provider webpack --profile --json > dist/stats.json",
+        "build": "webpack",
+        "build:dev": "webpack --mode=\"development\"",
+        "build:profile": "webpack --profile --json > dist/stats.json",
         "commit": "gitmoji -c",
         "lint": "eslint --fix src/**/*.ts",
         "lint:dry": "eslint --fix-dry-run src/**/*.ts",
         "release": "semantic-release",
         "release:dry": "semantic-release --dry-run",
-        "watch": "NODE_OPTIONS=--openssl-legacy-provider webpack --watch --mode=\"development\""
+        "watch": "webpack --watch --mode=\"development\""
     },
     "dependencies": {
-        "@spgoding/datapack-language-server": "3.4.16",
+        "@spgoding/datapack-language-server": "3.4.17",
         "vscode-languageclient": "^7.0.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "webpack-cli": "^3.3.11"
     },
     "extensionDependencies": [
-        "arcensoth.language-mcfunction"
+        "minecraftcommands.syntax-mcfunction"
     ],
     "repository": {
         "type": "git",


### PR DESCRIPTION
Simply adds 1.20.2 as a version that can be selected in the extension's configuration.
(This is also technically needed to make the new features in the upcoming DHP update work at all)